### PR TITLE
Allow extra spaces in some input fields

### DIFF
--- a/lib/lita/handlers/dig.rb
+++ b/lib/lita/handlers/dig.rb
@@ -10,7 +10,7 @@ module Lita
       route(
         /^dig
           (?:\s\@)?(?<resolver>\S+)?
-          \s(?<record>\S+)
+          (\s+(?<record>\S+))
           (?<type>\s\w+)?
           (?<short>\s\+short)?$
         /x,

--- a/spec/lita/handlers/dig_spec.rb
+++ b/spec/lita/handlers/dig_spec.rb
@@ -40,6 +40,7 @@ describe Lita::Handlers::Dig, lita_handler: true do
 
   it do
     is_expected.to route_command('dig example.com').to(:resolve)
+    is_expected.to route_command('dig  example.com').to(:resolve)
     is_expected.to route_command('dig example.com MX').to(:resolve)
     is_expected.to route_command('dig @8.8.8.8 example.com').to(:resolve)
     is_expected.to route_command('dig @8.8.8.8 example.com MX').to(:resolve)


### PR DESCRIPTION
Occasionally an extra space shows up when people use dig, possibly because it's 3AM, or from mobile.  Let's handle that a bit more gracefully.  CC @theckman
