### PR TITLE
Fix Rubocop lint issue, bump gem version for new release

### DIFF
--- a/lita-dig.gemspec
+++ b/lita-dig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-dig'
-  spec.version       = '1.0.0'
+  spec.version       = '1.1.0'
   spec.authors       = ['Eric Sigler']
   spec.email         = ['me@esigler.com']
   spec.description   = 'A DNS record lookup plugin for Lita'
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.metadata      = { 'lita_plugin_type' => 'handler' }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'


### PR DESCRIPTION
With https://github.com/esigler/lita-dig/pull/2 & https://github.com/esigler/lita-dig/pull/3 in, it's time for a new release!
