### PR TITLE
Update dependencies to use net-dns2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.1
+  - 2.2
 script: bundle exec rake
 before_install:
   - gem update --system

--- a/lita-dig.gemspec
+++ b/lita-dig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'lita-dig'
-  spec.version       = '1.1.0'
+  spec.version       = '1.2.0'
   spec.authors       = ['Eric Sigler']
   spec.email         = ['me@esigler.com']
   spec.description   = 'A DNS record lookup plugin for Lita'
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
-  spec.add_runtime_dependency 'net-dns'
+  spec.add_runtime_dependency 'net-dns2'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
net-dns gem is unmaintained since 2013, there are lots of fixes that will handle and fix #2.

By updating to the new gem, TXT responses worked again.
